### PR TITLE
Made mutations_sync configurable for lock statement via sys prop or env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ In this mode, liquibase will create its own tables as replicated.
 All changes in these files will be replicated on the entire cluster.
 Your updates should also affect the entire cluster either by using ON CLUSTER clause, or by using replicated tables.
 
+## Mutations sync
+
+The `mutations_sync` setting applied to the lock statement defaults to `2`
+(wait for mutations on all replicas). It can be overridden (in order of precedence) via:
+- System property - `liquibaseClickhouse.mutationsSync`
+- Environment variable - `LIQUIBASE_CLICKHOUSE_MUTATIONS_SYNC`
+
+Accepted values (see the ClickHouse `mutations_sync` setting):
+- `0` - mutation executes asynchronously, Liquibase does not wait for it to complete.
+- `1` - Liquibase waits for the mutation to complete on the current server only.
+- `2` - Liquibase waits for the mutation to complete on all replicas (default).
+
+Any invalid value falls back to the default `2`.
+
+For example, when building Liquibase programmatically you can set it before running the migration:
+```java
+System.setProperty("liquibaseClickhouse.mutationsSync", "1");
+```
+
 ## License
 
 Based on [MEDIARITHMICS/liquibase-clickhouse](https://github.com/mediarithmics/liquibase-clickhouse) 

--- a/src/main/java/io/goodforgod/liquibase/extension/clickhouse/params/ParamsLoader.java
+++ b/src/main/java/io/goodforgod/liquibase/extension/clickhouse/params/ParamsLoader.java
@@ -40,6 +40,50 @@ public class ParamsLoader {
         return missingProperties.toString();
     }
 
+    /**
+     * Resolves the {@code mutations_sync} setting value used when generating the lock statement.
+     * <p>
+     * The value can be configured (in order of precedence) via:
+     * <ul>
+     * <li>System property - {@code liquibaseClickhouse.mutationsSync}</li>
+     * <li>Environment variable - {@code LIQUIBASE_CLICKHOUSE_MUTATIONS_SYNC}</li>
+     * </ul>
+     * When nothing is configured the provided {@code defaultValue} is returned.
+     * <p>
+     * Accepted values (see the ClickHouse {@code mutations_sync} setting):
+     * <ul>
+     * <li>{@code 0} - mutation executes asynchronously, Liquibase does not wait for it to complete</li>
+     * <li>{@code 1} - Liquibase waits for the mutation to complete on the current server only</li>
+     * <li>{@code 2} - Liquibase waits for the mutation to complete on all replicas</li>
+     * </ul>
+     *
+     * @param defaultValue value returned when the setting is not configured
+     * @return the configured {@code mutations_sync} value or {@code defaultValue}
+     */
+    public static int getMutationsSync(int defaultValue) {
+        String value = Optional.ofNullable(System.getProperty("liquibaseClickhouse.mutationsSync"))
+                .or(() -> Optional.ofNullable(System.getenv("LIQUIBASE_CLICKHOUSE_MUTATIONS_SYNC")))
+                .orElse(null);
+
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            if (parsed < 0 || parsed > 2) {
+                throw new NumberFormatException("value out of range [0, 2]");
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            logger.warning("Invalid Clickhouse 'mutations_sync' value '"
+                    + value
+                    + "', expected one of 0, 1, 2. Falling back to default: "
+                    + defaultValue);
+            return defaultValue;
+        }
+    }
+
     public static ClusterConfig getLiquibaseClickhouseProperties() {
         String propFile = Optional.ofNullable(System.getProperty("liquibaseClickhousePropertiesFile"))
                 .or(() -> Optional.ofNullable(System.getenv("LIQUIBASE_CLICKHOUSE_PROPERTIES_FILE")))

--- a/src/main/java/io/goodforgod/liquibase/extension/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/io/goodforgod/liquibase/extension/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
@@ -33,18 +33,20 @@ public class LockDatabaseChangeLogClickHouse extends AbstractSqlGenerator<Clickh
                              Database database,
                              SqlGeneratorChain sqlGeneratorChain) {
         ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+        int mutationsSync = ParamsLoader.getMutationsSync(2);
 
         String lockQuery = String.format("ALTER TABLE `%s`.`%s` %s\n" +
                 "UPDATE LOCKED = 1, \n" +
                 "       LOCKEDBY = '%s', \n" +
                 "       LOCKGRANTED = %s \n" +
                 "WHERE ID = 1 AND LOCKED = 0 \n" +
-                "SETTINGS mutations_sync = 2",
+                "SETTINGS mutations_sync = %s",
                 database.getDefaultSchemaName(),
                 database.getDatabaseChangeLogLockTableName(),
                 SqlGeneratorUtil.generateSqlOnClusterClause(properties),
                 statement.getHost(),
-                ClickHouseDatabase.CURRENT_DATE_TIME_FUNCTION);
+                ClickHouseDatabase.CURRENT_DATE_TIME_FUNCTION,
+                mutationsSync);
 
         return SqlGeneratorUtil.generateSql(database, lockQuery);
     }

--- a/src/test/java/io/goodforgod/liquibase/extension/clickhouse/ParamsLoaderTests.java
+++ b/src/test/java/io/goodforgod/liquibase/extension/clickhouse/ParamsLoaderTests.java
@@ -23,4 +23,33 @@ public class ParamsLoaderTests {
         assertThrows(UnexpectedLiquibaseException.class,
                 () -> ParamsLoader.getLiquibaseClickhouseProperties("testLiquibaseClickhouseBroken.properties"));
     }
+
+    @Test
+    void mutationsSyncReturnsDefaultWhenNotConfigured() {
+        assertEquals(2, ParamsLoader.getMutationsSync(2));
+        assertEquals(1, ParamsLoader.getMutationsSync(1));
+    }
+
+    @Test
+    void mutationsSyncReadsSystemProperty() {
+        try {
+            System.setProperty("liquibaseClickhouse.mutationsSync", "0");
+            assertEquals(0, ParamsLoader.getMutationsSync(2));
+        } finally {
+            System.clearProperty("liquibaseClickhouse.mutationsSync");
+        }
+    }
+
+    @Test
+    void mutationsSyncFallsBackToDefaultOnInvalidValue() {
+        try {
+            System.setProperty("liquibaseClickhouse.mutationsSync", "not-a-number");
+            assertEquals(2, ParamsLoader.getMutationsSync(2));
+
+            System.setProperty("liquibaseClickhouse.mutationsSync", "5");
+            assertEquals(2, ParamsLoader.getMutationsSync(2));
+        } finally {
+            System.clearProperty("liquibaseClickhouse.mutationsSync");
+        }
+    }
 }


### PR DESCRIPTION
Makes the mutations_sync setting used in the lock statement configurable instead of hardcoding it to 2. 

Value can be set via system property `liquibaseClickhouse.mutationSync` or the env var `LIQUIBASE_CLICKHOUSE_MUTATIONS_SYNC`, and defaults to 2 (existing behavior).

Accepted values follow CH's own setting : 
- 0 asynchronous, no wait
- 1 wait on the current server only
- 2 wait on all replicas
- invalid values fallback to default